### PR TITLE
Add customizable item titles and seperate shoko ids stored for series and episodes

### DIFF
--- a/ShokoJellyfin/Configuration/PluginConfiguration.cs
+++ b/ShokoJellyfin/Configuration/PluginConfiguration.cs
@@ -5,38 +5,50 @@ namespace ShokoJellyfin.Configuration
     public class PluginConfiguration : BasePluginConfiguration
     {
         public string Host { get; set; }
-        
+
         public string Port { get; set; }
-        
+
         public string Username { get; set; }
-        
+
         public string Password { get; set; }
-        
+
         public string ApiKey { get; set; }
-        
+
         public bool UpdateWatchedStatus { get; set; }
-        
+
         public bool UseTvDbSeasonOrdering { get; set; }
-        
+
         public bool UseShokoThumbnails { get; set; }
-        
+
         public bool HideArtStyleTags { get; set; }
-        
+
         public bool HideSourceTags { get; set; }
-        
+
         public bool HideMiscTags { get; set; }
-        
+
         public bool HidePlotTags { get; set; }
 
         public bool HideAniDbTags { get; set; }
-        
+
         public bool SynopsisCleanLinks { get; set; }
-        
+
         public bool SynopsisCleanMiscLines { get; set; }
-        
+
         public bool SynopsisRemoveSummary { get; set; }
-        
+
         public bool SynopsisCleanMultiEmptyLines { get; set; }
+
+        public enum DisplayTitleType {
+            Default,
+            Localized,
+            Origin,
+        }
+
+        public bool TitleUseAlternate { get; set; }
+
+        public DisplayTitleType TitleMainType { get; set; }
+
+        public DisplayTitleType TitleAlternateType { get; set; }
 
         public PluginConfiguration()
         {
@@ -57,6 +69,9 @@ namespace ShokoJellyfin.Configuration
             SynopsisCleanMiscLines = true;
             SynopsisRemoveSummary = true;
             SynopsisCleanMultiEmptyLines = true;
+            TitleUseAlternate = true;
+            TitleMainType = DisplayTitleType.Default;
+            TitleAlternateType = DisplayTitleType.Origin;
         }
     }
 }

--- a/ShokoJellyfin/Configuration/configPage.html
+++ b/ShokoJellyfin/Configuration/configPage.html
@@ -27,25 +27,25 @@
                     <input is="emby-input" type="text" id="ApiKey" label="API Key" />
                     <div class="fieldDescription">This field is auto-generated using the credentials. Only set this manually if that doesn't work!</div>
                 </div>
-                <div class="selectContainer">
+                <div class="selectContainer selectContainer-withDescription">
                     <label class="selectLabel" for="TitleMainType">Main Title Language</label>
                     <select is="emby-select" id="TitleMainType" name="TitleMainType" class="emby-select-withcolor emby-select">
                         <option value="Default">Default</option>
-                        <option value="Localized">Use preffered metadata language</option>
+                        <option value="Localized">Use prefered metadata language</option>
                         <option value="Origin">Language in country of origin</option>
                     </select>
                     <div class="fieldDescription">Titles will fallback to Default if not found for the target language.</div>
                 </div>
-                <div class="selectContainer">
+                <div class="selectContainer selectContainer-withDescription">
                     <label class="selectLabel" for="TitleAlternateType">Alternate Title Language</label>
                     <select is="emby-select" id="TitleAlternateType" name="TitleAlternateType" class="emby-select-withcolor emby-select">
                         <option value="Default">Default</option>
-                        <option value="Localized">Use preffered metadata language</option>
+                        <option value="Localized">Use prefered metadata language</option>
                         <option value="Origin">Language in country of origin</option>
                     </select>
                     <div class="fieldDescription">Titles >will fallback to Default if not found for the target language.</div>
                 </div>
-                <label class="checkboxContainer">
+                <label class="checkboxContainer checkboxContainer-withDescription">
                     <input is="emby-checkbox" type="checkbox" id="TitleUseAlternate" />
                     <span>Include an alternate title</span>
                     <div class="fieldDescription">Will populate the &#34;Original Title&#34; field with the alternate title.</div>

--- a/ShokoJellyfin/Configuration/configPage.html
+++ b/ShokoJellyfin/Configuration/configPage.html
@@ -31,7 +31,7 @@
                     <label class="selectLabel" for="TitleMainType">Main Title Language</label>
                     <select is="emby-select" id="TitleMainType" name="TitleMainType" class="emby-select-withcolor emby-select">
                         <option value="Default">Default</option>
-                        <option value="Localized">Use prefered metadata language</option>
+                        <option value="Localized">Use preferred metadata language</option>
                         <option value="Origin">Language in country of origin</option>
                     </select>
                     <div class="fieldDescription">Titles will fallback to Default if not found for the target language.</div>
@@ -40,7 +40,7 @@
                     <label class="selectLabel" for="TitleAlternateType">Alternate Title Language</label>
                     <select is="emby-select" id="TitleAlternateType" name="TitleAlternateType" class="emby-select-withcolor emby-select">
                         <option value="Default">Default</option>
-                        <option value="Localized">Use prefered metadata language</option>
+                        <option value="Localized">Use preferred metadata language</option>
                         <option value="Origin">Language in country of origin</option>
                     </select>
                     <div class="fieldDescription">Titles will fallback to Default if not found for the target language.</div>

--- a/ShokoJellyfin/Configuration/configPage.html
+++ b/ShokoJellyfin/Configuration/configPage.html
@@ -43,7 +43,7 @@
                         <option value="Localized">Use prefered metadata language</option>
                         <option value="Origin">Language in country of origin</option>
                     </select>
-                    <div class="fieldDescription">Titles >will fallback to Default if not found for the target language.</div>
+                    <div class="fieldDescription">Titles will fallback to Default if not found for the target language.</div>
                 </div>
                 <label class="checkboxContainer checkboxContainer-withDescription">
                     <input is="emby-checkbox" type="checkbox" id="TitleUseAlternate" />

--- a/ShokoJellyfin/Configuration/configPage.html
+++ b/ShokoJellyfin/Configuration/configPage.html
@@ -27,6 +27,29 @@
                     <input is="emby-input" type="text" id="ApiKey" label="API Key" />
                     <div class="fieldDescription">This field is auto-generated using the credentials. Only set this manually if that doesn't work!</div>
                 </div>
+                <div class="selectContainer">
+                    <label class="selectLabel" for="TitleMainType">Main Title Language</label>
+                    <select is="emby-select" id="TitleMainType" name="TitleMainType" class="emby-select-withcolor emby-select">
+                        <option value="Default">Default</option>
+                        <option value="Localized">Use preffered metadata language</option>
+                        <option value="Origin">Language in country of origin</option>
+                    </select>
+                    <div class="fieldDescription">Titles will fallback to Default if not found for the target language.</div>
+                </div>
+                <div class="selectContainer">
+                    <label class="selectLabel" for="TitleAlternateType">Alternate Title Language</label>
+                    <select is="emby-select" id="TitleAlternateType" name="TitleAlternateType" class="emby-select-withcolor emby-select">
+                        <option value="Default">Default</option>
+                        <option value="Localized">Use preffered metadata language</option>
+                        <option value="Origin">Language in country of origin</option>
+                    </select>
+                    <div class="fieldDescription">Titles >will fallback to Default if not found for the target language.</div>
+                </div>
+                <label class="checkboxContainer">
+                    <input is="emby-checkbox" type="checkbox" id="TitleUseAlternate" />
+                    <span>Include an alternate title</span>
+                    <div class="fieldDescription">Will populate the &#34;Original Title&#34; field with the alternate title.</div>
+                </label>
                 <label class="checkboxContainer">
                     <input is="emby-checkbox" type="checkbox" id="UpdateWatchedStatus" />
                     <span>Update watched status on Shoko (Scrobble)</span>
@@ -87,7 +110,7 @@
         var PluginConfig = {
             pluginId: "5216ccbf-d24a-4eb3-8a7e-7da4230b7052"
         };
-        
+
         document.querySelector('.shokoConfigPage')
                 .addEventListener('pageshow', function () {
                     Dashboard.showLoadingMsg();
@@ -108,15 +131,18 @@
                         document.querySelector('#SynopsisCleanLinks').checked = config.SynopsisCleanLinks;
                         document.querySelector('#SynopsisCleanMiscLines').checked = config.SynopsisCleanMiscLines;
                         document.querySelector('#SynopsisRemoveSummary').checked = config.SynopsisRemoveSummary;
-                        document.querySelector('#SynopsisCleanMultiEmptyLines').checked = config.SynopsisCleanMultiEmptyLines;                        
+                        document.querySelector('#SynopsisCleanMultiEmptyLines').checked = config.SynopsisCleanMultiEmptyLines;
+                        document.querySelector('#TitleUseAlternate').checked = config.TitleUseAlternate;
+                        document.querySelector('#TitleMainType').value = config.TitleMainType;
+                        document.querySelector('#TitleAlternateType').value = config.TitleAlternateType;
                         Dashboard.hideLoadingMsg();
                     });
                 });
-                
+
         document.querySelector('.shokoConfigForm')
                 .addEventListener('submit', function (e) {
                     Dashboard.showLoadingMsg();
-    
+
                     ApiClient.getPluginConfiguration(PluginConfig.pluginId).then(function (config) {
                         config.Host = document.querySelector('#Host').value;
                         config.Port = document.querySelector('#Port').value;
@@ -124,7 +150,7 @@
                         config.Password = document.querySelector('#Password').value;
                         config.ApiKey = document.querySelector('#ApiKey').value;
                         config.UpdateWatchedStatus = document.querySelector('#UpdateWatchedStatus').checked;
-                        config.UseTvDbSeasonOrdering = document.querySelector('#UseTvDbSeasonOrdering').checked; 
+                        config.UseTvDbSeasonOrdering = document.querySelector('#UseTvDbSeasonOrdering').checked;
                         config.UseShokoThumbnails = document.querySelector('#UseShokoThumbnails').checked;
                         config.HideArtStyleTags = document.querySelector('#HideArtStyleTags').checked;
                         config.HideSourceTags = document.querySelector('#HideSourceTags').checked;
@@ -134,10 +160,13 @@
                         config.SynopsisCleanLinks = document.querySelector('#SynopsisCleanLinks').checked;
                         config.SynopsisCleanMiscLines = document.querySelector('#SynopsisCleanMiscLines').checked;
                         config.SynopsisRemoveSummary = document.querySelector('#SynopsisRemoveSummary').checked;
-                        config.SynopsisCleanMultiEmptyLines = document.querySelector('#SynopsisCleanMultiEmptyLines').checked;                        
+                        config.SynopsisCleanMultiEmptyLines = document.querySelector('#SynopsisCleanMultiEmptyLines').checked;
+                        config.TitleUseAlternate = document.querySelector('#TitleUseAlternate').checked;
+                        config.TitleMainType = document.querySelector('#TitleMainType').value;
+                        config.TitleAlternateType = document.querySelector('#TitleAlternateType').value;
                         ApiClient.updatePluginConfiguration(PluginConfig.pluginId, config).then(Dashboard.processPluginConfigurationUpdateResult);
                     });
-                    
+
                     e.preventDefault();
                     return false;
                 });

--- a/ShokoJellyfin/ExternalIds.cs
+++ b/ShokoJellyfin/ExternalIds.cs
@@ -1,0 +1,62 @@
+using MediaBrowser.Controller.Entities.TV;
+using MediaBrowser.Controller.Entities.Movies;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Entities;
+using MediaBrowser.Model.Providers;
+
+namespace ShokoJellyfin
+{
+    public class AniDbExternalId : IExternalId
+    {
+        public bool Supports(IHasProviderIds item)
+            => item is Series || item is Episode || item is Movie || item is BoxSet;
+
+        public string ProviderName
+            => "AniDB";
+
+        public string Key
+            => "AniDB";
+
+        public ExternalIdMediaType? Type
+            => null;
+
+        public string UrlFormatString
+            => null;
+    }
+
+    public class ShokoSeriesExternalId : IExternalId
+    {
+        public bool Supports(IHasProviderIds item)
+            => item is Series || item is Episode || item is Movie || item is BoxSet;
+
+        public string ProviderName
+            => "Shoko Series";
+
+        public string Key
+            => "Shoko Series";
+
+        public ExternalIdMediaType? Type
+            => null;
+
+        public string UrlFormatString
+            => null;
+    }
+
+    public class ShokoEpisodeExternalId : IExternalId
+    {
+        public bool Supports(IHasProviderIds item)
+            => item is Episode || item is Movie;
+
+        public string ProviderName
+            => "Shoko Episode";
+
+        public string Key
+            => "Shoko Episode";
+
+        public ExternalIdMediaType? Type
+            => null;
+
+        public string UrlFormatString
+            => null;
+    }
+}

--- a/ShokoJellyfin/ExternalIds.cs
+++ b/ShokoJellyfin/ExternalIds.cs
@@ -27,7 +27,7 @@ namespace ShokoJellyfin
     public class ShokoSeriesExternalId : IExternalId
     {
         public bool Supports(IHasProviderIds item)
-            => item is Series || item is Episode || item is Movie || item is BoxSet;
+            => item is Series || item is Movie || item is BoxSet;
 
         public string ProviderName
             => "Shoko Series";

--- a/ShokoJellyfin/ExternalIds.cs
+++ b/ShokoJellyfin/ExternalIds.cs
@@ -6,24 +6,6 @@ using MediaBrowser.Model.Providers;
 
 namespace ShokoJellyfin
 {
-    public class AniDbExternalId : IExternalId
-    {
-        public bool Supports(IHasProviderIds item)
-            => item is Series || item is Episode || item is Movie || item is BoxSet;
-
-        public string ProviderName
-            => "AniDB";
-
-        public string Key
-            => "AniDB";
-
-        public ExternalIdMediaType? Type
-            => null;
-
-        public string UrlFormatString
-            => null;
-    }
-
     public class ShokoSeriesExternalId : IExternalId
     {
         public bool Supports(IHasProviderIds item)

--- a/ShokoJellyfin/Providers/EpisodeProvider.cs
+++ b/ShokoJellyfin/Providers/EpisodeProvider.cs
@@ -46,7 +46,7 @@ namespace ShokoJellyfin.Providers
                 var episodeIDs = allIds?.EpisodeIDs?.FirstOrDefault();
                 var episodeId = episodeIDs?.ID.ToString();
 
-                if (string.IsNullOrEmpty(episodeId))
+                if (string.IsNullOrEmpty(seriesId) || string.IsNullOrEmpty(episodeId))
                 {
                     _logger.LogInformation($"Shoko Scanner... Episode not found! ({filename})");
                     return result;

--- a/ShokoJellyfin/Providers/EpisodeProvider.cs
+++ b/ShokoJellyfin/Providers/EpisodeProvider.cs
@@ -68,7 +68,6 @@ namespace ShokoJellyfin.Providers
                     Overview = Helper.SummarySanitizer(episodeInfo.Description),
                     CommunityRating = (float) ((episodeInfo.Rating.Value * 10) / episodeInfo.Rating.MaxValue)
                 };
-                result.Item.SetProviderId("Shoko Series", seriesId);
                 result.Item.SetProviderId("Shoko Episode", episodeId);
                 result.Item.SetProviderId("AniDB", episodeIDs.AniDB.ToString());
                 var tvdbId = episodeIDs.TvDB?.FirstOrDefault();

--- a/ShokoJellyfin/Providers/EpisodeProvider.cs
+++ b/ShokoJellyfin/Providers/EpisodeProvider.cs
@@ -41,8 +41,9 @@ namespace ShokoJellyfin.Providers
                 _logger.LogInformation($"Shoko Scanner... Getting episode ID ({filename})");
 
                 var apiResponse = await ShokoAPI.GetFilePathEndsWith(filename);
-                var allIds = apiResponse.FirstOrDefault()?.SeriesIDs.FirstOrDefault()?.EpisodeIDs;
-                var episodeIDs = allIds?.FirstOrDefault();
+                var allIds = apiResponse.FirstOrDefault()?.SeriesIDs.FirstOrDefault();
+                var seriesId = allIds?.SeriesID.ID.ToString();
+                var episodeIDs = allIds?.EpisodeIDs?.FirstOrDefault();
                 var episodeId = episodeIDs?.ID.ToString();
 
                 if (string.IsNullOrEmpty(episodeId))
@@ -53,24 +54,28 @@ namespace ShokoJellyfin.Providers
 
                 _logger.LogInformation($"Shoko Scanner... Getting episode metadata ({filename} - {episodeId})");
 
+                var seriesInfo = await ShokoAPI.GetSeriesAniDb(seriesId);
                 var episodeInfo = await ShokoAPI.GetEpisodeAniDb(episodeId);
+                var ( displayTitle, alternateTitle ) = Helper.GetEpisodeTitles(seriesInfo.Titles, episodeInfo.Titles, Plugin.Instance.Configuration.TitleMainType, Plugin.Instance.Configuration.TitleAlternateType, info.MetadataLanguage);
 
                 result.Item = new Episode
                 {
                     IndexNumber = episodeInfo.EpisodeNumber,
                     ParentIndexNumber = await GetSeasonNumber(episodeId, episodeInfo.Type),
-                    Name = episodeInfo.Titles.Find(title => title.Language.Equals("EN"))?.Name,
+                    Name = displayTitle,
+                    OriginalTitle = alternateTitle,
                     PremiereDate = episodeInfo.AirDate,
                     Overview = Helper.SummarySanitizer(episodeInfo.Description),
                     CommunityRating = (float) ((episodeInfo.Rating.Value * 10) / episodeInfo.Rating.MaxValue)
                 };
-                result.Item.SetProviderId("Shoko", episodeId);
+                result.Item.SetProviderId("Shoko Series", seriesId);
+                result.Item.SetProviderId("Shoko Episode", episodeId);
                 result.Item.SetProviderId("AniDB", episodeIDs.AniDB.ToString());
                 var tvdbId = episodeIDs.TvDB?.FirstOrDefault();
                 if (tvdbId != 0) result.Item.SetProviderId("Tvdb", tvdbId.ToString());
                 result.HasMetadata = true;
 
-                var episodeNumberEnd = episodeInfo.EpisodeNumber + allIds.Count() - 1;
+                var episodeNumberEnd = episodeInfo.EpisodeNumber + allIds?.EpisodeIDs.Count() - 1;
                 if (episodeInfo.EpisodeNumber != episodeNumberEnd) result.Item.IndexNumberEnd = episodeNumberEnd;
 
                 return result;

--- a/ShokoJellyfin/Providers/Helper.cs
+++ b/ShokoJellyfin/Providers/Helper.cs
@@ -1,5 +1,10 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using System.Text.RegularExpressions;
 using ShokoJellyfin.API.Models;
+using Title = ShokoJellyfin.API.Models.Title;
+using DisplayTitleType = ShokoJellyfin.Configuration.PluginConfiguration.DisplayTitleType;
 
 namespace ShokoJellyfin.Providers
 {
@@ -27,6 +32,130 @@ namespace ShokoJellyfin.Providers
                 summary = Regex.Replace(summary, @"\n\n+", "", RegexOptions.Singleline); 
 
             return summary;
+        }
+
+        // Produce titles for episodes if the series-fallback-title is not provided.
+        public static ( string, string ) GetEpisodeTitles(IEnumerable<Title> seriesTitles, IEnumerable<Title> episodeTitles, DisplayTitleType displayTitleType, DisplayTitleType alternateTitleType, string metadataLanguage)
+            => GetFullTitles(seriesTitles, episodeTitles, null, displayTitleType, alternateTitleType, metadataLanguage);
+
+        // Produce titles for series if episode titles are omitted.
+        public static ( string, string ) GetSeriesTitles(IEnumerable<Title> seriesTitles, string seriesTitle, DisplayTitleType displayTitleType, DisplayTitleType alternateTitleType, string metadataLanguage)
+            => GetFullTitles(seriesTitles, null, seriesTitle, displayTitleType, alternateTitleType, metadataLanguage);
+
+        // Produce combined/full titles if both episode titles and a fallback title is provided.
+        public static ( string, string ) GetFullTitles(IEnumerable<Title> rSeriesTitles, IEnumerable<Title> rEpisodeTitles, string seriesTitle, DisplayTitleType displayTitleType, DisplayTitleType alternateTitleType, string metadataLanguage)
+        {
+            // Don't process anything if the series titles are not provided.
+            if (rSeriesTitles == null) return ( null, null );
+            var seriesTitles = (List<Title>)rSeriesTitles;
+            var episodeTitles = (List<Title>)rEpisodeTitles;
+            var originLanguage = GuessOriginLanguage(seriesTitles);
+            var displayLanguage = GuessDisplayLanguage(metadataLanguage);
+            return ( GetFullTitle(seriesTitles, episodeTitles, seriesTitle, displayTitleType, displayLanguage, originLanguage), GetFullTitle(seriesTitles, episodeTitles, seriesTitle, alternateTitleType, displayLanguage, originLanguage) );
+        }
+
+        private static string GetEpisodeTitle(IEnumerable<Title> episodeTitle, DisplayTitleType displayTitleType, string displayLanguage, params string[] originLanguages)
+            => GetFullTitle(null, episodeTitle, null, displayTitleType, displayLanguage, originLanguages);
+
+        private static string GetSeriesTitle(IEnumerable<Title> seriesTitles, string seriesTitle, DisplayTitleType displayTitleType, string displayLanguage, params string[] originLanguages)
+            => GetFullTitle(seriesTitles, null, seriesTitle, displayTitleType, displayLanguage, originLanguages);
+
+        private static string GetFullTitle(IEnumerable<Title> seriesTitles, IEnumerable<Title> episodeTitles, string seriesTitle, DisplayTitleType displayTitleType, string displayLanguage, params string[] originLanguages)
+        {
+            // We need one of them, or it won't work as intended.
+            if (seriesTitle == null && episodeTitles == null) return null;
+            switch (displayTitleType)
+            {
+                case DisplayTitleType.Default:
+                    // Fallback to preffered series title, but choose the episode title based on this order.
+                    // The "main" title on AniDB is _most_ of the time in english, but we also fallback to romanji (japanese) or pinyin (chinese) in case it is not provided in.
+                    return GetTitle(null, episodeTitles, seriesTitle, "en", "x-jat", "x-zht");
+                case DisplayTitleType.Origin:
+                    return GetTitle(seriesTitles, episodeTitles, seriesTitle, originLanguages);
+                case DisplayTitleType.Localized:
+                    var title = GetTitle(seriesTitles, episodeTitles, seriesTitle, displayLanguage);
+                    if (string.IsNullOrEmpty(title))
+                        goto case DisplayTitleType.Default;
+                    return title;
+                default:
+                    return null;
+            }
+        }
+
+        private static string GetTitle(IEnumerable<Title> seriesTitles, IEnumerable<Title> episodeTitles, string seriesTitle, params string[] languageCandidates)
+        {
+            if (seriesTitles != null || seriesTitle != null)
+            {
+                StringBuilder title = new StringBuilder();
+                string mainTitle = GetTitleByTypeAndLanguage(seriesTitles, "official", languageCandidates) ?? seriesTitle;
+                title.Append(mainTitle);
+                if (episodeTitles != null) {
+                    var episodeTitle = GetTitleByLanguages(episodeTitles, languageCandidates);
+                    // We could not find the complete title, and no mixed languages (outside the spesified ones), so abort here.
+                    if (episodeTitle == null)
+                    {
+                        // Some movies provide only an english title, so we fallback to english.
+                        episodeTitle = GetTitleByLanguages(episodeTitles, "en");
+                        if (episodeTitle == null)
+                            return null;
+                    }
+                    if (!string.IsNullOrWhiteSpace(episodeTitle) && episodeTitle != "Complete Movie")
+                        title.Append($": {episodeTitle}");
+                }
+                return title.ToString();
+            }
+            // Will fallback to null if episode titles are null.
+            return GetTitleByLanguages(episodeTitles, languageCandidates);
+        }
+
+        private static string GetTitleByTypeAndLanguage(IEnumerable<Title> titles, string type, params string[] langs)
+        {
+            if (titles != null) foreach (string lang in langs)
+            {
+                string title = titles.FirstOrDefault(s => s.Language == lang && s.Type == type)?.Name;
+                if (title != null) return title;
+            }
+            return null;
+        }
+
+        private static string GetTitleByLanguages(IEnumerable<Title> titles, params string[] langs)
+        {
+            if (titles != null) foreach (string lang in langs)
+            {
+                string title = titles.FirstOrDefault(s => s.Language.ToLower() == lang)?.Name;
+                if (title != null) return title;
+            }
+            return null;
+        }
+
+        // Guess the origin language based on the main title.
+        private static string[] GuessOriginLanguage(IEnumerable<Title> seriesTitle)
+        {
+            string langCode = seriesTitle.FirstOrDefault(t => t?.Type == "main")?.Language.ToLower();
+            // Guess the origin language based on the main title.
+            switch (langCode)
+            {
+                case null: // fallback
+                case "x-other":
+                case "x-jat":
+                    return new string[] { "ja" };
+                case "x-zht":
+                    return new string[] { "zn-hans", "zn-hant", "zn-c-mcm", "zn" };
+                default:
+                    return new string[] { langCode };
+            }
+
+        }
+
+        private static string GuessDisplayLanguage(string metadataLanguage)
+        {
+            switch (metadataLanguage)
+            {
+                // TODO: Add more cases, or provide a converter function to country-code.
+                case null:
+                default:
+                    return "en";
+            }
         }
     }
 }

--- a/ShokoJellyfin/Providers/Helper.cs
+++ b/ShokoJellyfin/Providers/Helper.cs
@@ -67,8 +67,8 @@ namespace ShokoJellyfin.Providers
             switch (displayTitleType)
             {
                 case DisplayTitleType.Default:
-                    // Fallback to preffered series title, but choose the episode title based on this order.
-                    // The "main" title on AniDB is _most_ of the time in english, but we also fallback to romanji (japanese) or pinyin (chinese) in case it is not provided in.
+                    // Fallback to prefered series title, but choose the episode title based on this order.
+                    // The "main" title on AniDB is _most_ of the time in english, but we also fallback to romaji (japanese) or pinyin (chinese) in case it is not provided.
                     return GetTitle(null, episodeTitles, seriesTitle, "en", "x-jat", "x-zht");
                 case DisplayTitleType.Origin:
                     return GetTitle(seriesTitles, episodeTitles, seriesTitle, originLanguages);
@@ -91,7 +91,7 @@ namespace ShokoJellyfin.Providers
                 title.Append(mainTitle);
                 if (episodeTitles != null) {
                     var episodeTitle = GetTitleByLanguages(episodeTitles, languageCandidates);
-                    // We could not find the complete title, and no mixed languages (outside the spesified ones), so abort here.
+                    // We could not create the complete title, and no mixed languages allowed (outside the specified one(s)), so abort here.
                     if (episodeTitle == null)
                     {
                         // Some movies provide only an english title, so we fallback to english.

--- a/ShokoJellyfin/Providers/Helper.cs
+++ b/ShokoJellyfin/Providers/Helper.cs
@@ -50,7 +50,7 @@ namespace ShokoJellyfin.Providers
             var seriesTitles = (List<Title>)rSeriesTitles;
             var episodeTitles = (List<Title>)rEpisodeTitles;
             var originLanguage = GuessOriginLanguage(seriesTitles);
-            var displayLanguage = GuessDisplayLanguage(metadataLanguage);
+            var displayLanguage = metadataLanguage?.ToLower() ?? "en";
             return ( GetFullTitle(seriesTitles, episodeTitles, seriesTitle, displayTitleType, displayLanguage, originLanguage), GetFullTitle(seriesTitles, episodeTitles, seriesTitle, alternateTitleType, displayLanguage, originLanguage) );
         }
 
@@ -145,17 +145,6 @@ namespace ShokoJellyfin.Providers
                     return new string[] { langCode };
             }
 
-        }
-
-        private static string GuessDisplayLanguage(string metadataLanguage)
-        {
-            switch (metadataLanguage)
-            {
-                // TODO: Add more cases, or provide a converter function to country-code.
-                case null:
-                default:
-                    return "en";
-            }
         }
     }
 }

--- a/ShokoJellyfin/Providers/Helper.cs
+++ b/ShokoJellyfin/Providers/Helper.cs
@@ -67,7 +67,7 @@ namespace ShokoJellyfin.Providers
             switch (displayTitleType)
             {
                 case DisplayTitleType.Default:
-                    // Fallback to prefered series title, but choose the episode title based on this order.
+                    // Fallback to preferred series title, but choose the episode title based on this order.
                     // The "main" title on AniDB is _most_ of the time in english, but we also fallback to romaji (japanese) or pinyin (chinese) in case it is not provided.
                     return GetTitle(null, episodeTitles, seriesTitle, "en", "x-jat", "x-zht");
                 case DisplayTitleType.Origin:

--- a/ShokoJellyfin/Providers/SeriesProvider.cs
+++ b/ShokoJellyfin/Providers/SeriesProvider.cs
@@ -53,10 +53,12 @@ namespace ShokoJellyfin.Providers
                 var seriesInfo = await ShokoAPI.GetSeries(seriesId);
                 var aniDbSeriesInfo = await ShokoAPI.GetSeriesAniDb(seriesId);
                 var tags = await ShokoAPI.GetSeriesTags(seriesId, GetFlagFilter());
+                var ( displayTitle, alternateTitle ) = Helper.GetSeriesTitles(aniDbSeriesInfo.Titles, aniDbSeriesInfo.Title, Plugin.Instance.Configuration.TitleMainType, Plugin.Instance.Configuration.TitleAlternateType, info.MetadataLanguage);
                 
                 result.Item = new Series
                 {
-                    Name = seriesInfo.Name,
+                    Name = displayTitle,
+                    OriginalTitle = alternateTitle,
                     Overview = Helper.SummarySanitizer(aniDbSeriesInfo.Description),
                     PremiereDate = aniDbSeriesInfo.AirDate,
                     EndDate = aniDbSeriesInfo.EndDate,

--- a/ShokoJellyfin/Providers/SeriesProvider.cs
+++ b/ShokoJellyfin/Providers/SeriesProvider.cs
@@ -67,7 +67,7 @@ namespace ShokoJellyfin.Providers
                     Tags = tags?.Select(tag => tag.Name).ToArray() ?? new string[0],
                     CommunityRating = (float)((aniDbSeriesInfo.Rating.Value * 10) / aniDbSeriesInfo.Rating.MaxValue)
                 };
-                result.Item.SetProviderId("Shoko", seriesId);
+                result.Item.SetProviderId("Shoko Series", seriesId);
                 result.Item.SetProviderId("AniDB", seriesIDs.AniDB.ToString());
                 var tvdbId = seriesIDs.TvDB?.FirstOrDefault();
                 if (tvdbId != 0) result.Item.SetProviderId("Tvdb", tvdbId.ToString());


### PR DESCRIPTION
Changes included in this PR:
- The ability to customize display title for entries (e.g. series, episode or movies).
- Episodes now store _both_ the episode _and the_ series id, because we need the series info to figure out the COO (country of origin).
- When viewing metadata of a series, episode, movie or movie box-set (the last two types will be added in another PR), the ids for Shoko associated with the entry will be shown under "External IDs".